### PR TITLE
Make owner and repo optional for protect-branch

### DIFF
--- a/workspaces/varys/bin/varys-repos-protect-branch
+++ b/workspaces/varys/bin/varys-repos-protect-branch
@@ -3,25 +3,77 @@
 'use strict'
 
 const program = require('commander')
-const chalk = require('chalk')
+const inquirer = require('inquirer')
 
 const pkg = require('../package.json')
 const {
   config: { defaultConfiguration },
   logger: { infoMessage },
-  commands: { setBranchProtection }
+  commands: { fetchRepositories, setBranchProtection }
 } = require('../lib')
+
+const getRepos = async organization =>
+  (
+    await fetchRepositories({
+      token: defaultConfiguration.githubToken,
+      name: organization.name
+    })
+  ).organization.repositories.nodes.map(repository => ({
+    owner: organization.name,
+    repository: repository.name
+  }))
+
+const listRepos = orgRepos =>
+  orgRepos.map(orgRepo => `${orgRepo.owner}/${orgRepo.repository}`).join('\n')
+
+const confirmProtectPrompt = orgRepos => ({
+  message: `Do you want to protect the master branch for the following repositories?
+${listRepos(orgRepos)}
+`,
+  name: 'proceed',
+  type: 'confirm',
+  default: false
+})
+
+const getAllRepos = async organizations => {
+  const orgs = []
+  for (let org of organizations) {
+    orgs.push(...(await getRepos(org)))
+  }
+  return orgs
+}
+
+const printRepoInfo = ({ owner, repository }) =>
+  infoMessage(`protecting master branch for ${owner}/${repository}`)
 
 program
   .version(pkg.version)
   .description(pkg.description)
-  .arguments('<owner> <repo>')
-  .action(function(owner, repo) {
-    infoMessage(chalk`protect master branch`)
-    setBranchProtection(defaultConfiguration, {
-      owner,
-      repository: repo,
-      branchPattern: 'master'
-    })
+  .arguments('[owner] [repo]')
+  .action(async function(owner, repo) {
+    if (!repo) {
+      infoMessage('fetching repositories')
+      const orgRepos = !owner
+        ? await getAllRepos(defaultConfiguration.organizations)
+        : await getRepos({ name: owner })
+
+      const confirm = await inquirer.prompt(confirmProtectPrompt(orgRepos))
+      if (confirm.proceed) {
+        orgRepos.forEach(orgRepo => {
+          printRepoInfo(orgRepo)
+          setBranchProtection(defaultConfiguration, {
+            ...orgRepo,
+            branchPattern: 'master'
+          })
+        })
+      }
+    } else {
+      const orgRepo = { owner, repository: repo }
+      printRepoInfo(orgRepo)
+      setBranchProtection(defaultConfiguration, {
+        ...orgRepo,
+        branchPattern: 'master'
+      })
+    }
   })
   .parse(process.argv)

--- a/workspaces/varys/lib/commands/show-repositories-graphql.js
+++ b/workspaces/varys/lib/commands/show-repositories-graphql.js
@@ -88,5 +88,6 @@ const showRepositories = async (config, filterOrgs) => {
 }
 
 module.exports = {
-  showRepositories
+  showRepositories,
+  fetchRepositories
 }


### PR DESCRIPTION
This allows to protect all master branches for all the repositories of a single organization or all organizations at once.

```bash
$ bin/varys repos protect-branch philips-labs
v fetching repositories
? Do you want to protect the master branch for the following repositories?
philips-labs/dct-notary-admin
philips-labs/notary
philips-labs/about-this-organization
philips-labs/sonar-scanner-action
philips-labs/medical-delivery-drone
philips-labs/dangerous-dave
philips-labs/garo
philips-labs/aws-ecr-scanning-slack-notifications
philips-labs/hmac
philips-labs/refactor-card-game
philips-labs/github-action-repolinter
philips-labs/docker-github-actions-runner
philips-labs/siderite
philips-labs/blackduck-scanner-action
philips-labs/fluent-bit-out-hsdp
philips-labs/iron-streaming-backup
philips-labs/cf-centrifugo
 No
```

or 

```bash
$ bin/varys repos protect-branch
v fetching repositories
? Do you want to protect the master branch for the following repositories?
philips-labs/dct-notary-admin
philips-labs/notary
philips-labs/about-this-organization
philips-labs/sonar-scanner-action
....
.....
...
...
..
 No
```