### PR TITLE
Slack channel is now configurable in `organizations.json`

### DIFF
--- a/workspaces/varys/CHANGELOG.md
+++ b/workspaces/varys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Changes
+
+- #41 - Slack channel moved to configuration
+
 ## 0.0.1
 
 Initial version

--- a/workspaces/varys/CODEOWNERS
+++ b/workspaces/varys/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @philips-internal/softwareconcepts
+*       @philips-labs/innersource-tooling

--- a/workspaces/varys/README.md
+++ b/workspaces/varys/README.md
@@ -2,6 +2,21 @@
 
 ## Description
 
+## Configuration
+
+Create a file `organizations.json` with information about your organization.
+Example configuration: [organizations.json.example](./organizations.json.example)
+
+### Configuration
+
+| key             | description                          |
+| --------------- | ------------------------------------ |
+| `githubToken`   | GitHub token                         |
+| `enterprise`    | Enterprise organization, for SSO     |
+| `organizations` | Array with organizations             |
+| `slackToken`    | Slack Token                          |
+| `slackChannel`  | Slack Channel                        |
+
 ## Usage
 
 ```bash

--- a/workspaces/varys/lib/commands/add-user-graphql.js
+++ b/workspaces/varys/lib/commands/add-user-graphql.js
@@ -8,6 +8,7 @@ import { infoMessage, errorMessage } from '../logger'
 
 let token
 let slackToken
+let slackChannel
 
 const checkOrganization = ({ organizations }, organization) => {
   for (const ourOrganization of organizations) {
@@ -155,6 +156,7 @@ const processAction = async (username, organization) => {
   infoMessage(
     chalk`Add ${chalk.yellow(username)} to ${chalk.green(organization)}`
   )
+
   const octokit = new Octokit({
     auth: token
   })
@@ -168,18 +170,23 @@ const processAction = async (username, organization) => {
     chalk`Added ${chalk.yellow(username)} to ${chalk.green(organization)}`
   )
 
-  const bot = new Slack(slackToken)
-  await bot.chat.postMessage({
-    channel: '#royal-philips',
-    text: `Added *${username}* to *${organization}*`,
-    token: slackToken
-  })
+  if (!slackToken || !slackChannel) {
+    infoMessage(chalk`Missing mandatory slack parameters so no slack message today!`)
+  } else {
+    const bot = new Slack(slackToken)
+    await bot.chat.postMessage({
+      channel: slackChannel,
+      text: `Added *${username}* to *${organization}*`,
+      token: slackToken
+    })
+  }
   console.log(data)
 }
 
 const addUsers = async (config, { organization, users, team }) => {
   token = config.githubToken
   slackToken = config.slackToken
+  slackChannel = config.slackChannel
 
   team = team || ''
 

--- a/workspaces/varys/organizations.json.example
+++ b/workspaces/varys/organizations.json.example
@@ -1,13 +1,13 @@
 {
   "githubToken": "<awesome-token-here>",
-  "enterprise": "royal-philips",
+  "enterprise": "<enterprise-organization-name>",
   "organizations": [
-    { 
-      "name": "philips-software", 
-      "id": 12321 
+    {
+      "name": "philips-software"
     },
-    { "name": "philips-labs", 
-      "id": 12323 
+    { "name": "philips-labs"
     }
-  ]
+  ],
+  "slackToken": "<slackToken>",
+  "slackChannel": "#varys-channel"
 }


### PR DESCRIPTION
Now you can pass the `slackChannel` in `organizations.json`..

If either `slackChannel` or `slackToken` is missing, no message will be send at all.
See README.md

Closes #41, #42 