### PR TITLE
Invited users are automatically added to a default team

### DIFF
--- a/workspaces/varys/bin/varys-users-add
+++ b/workspaces/varys/bin/varys-users-add
@@ -15,7 +15,6 @@ program
   .version(pkg.version)
   .description(pkg.description)
   .option('-o, --organization <organization-name>', 'To which organization')
-  .option('-t, --team <team-name>', 'Which team (optional)')
   .arguments('[users...]')
   .action(function(users, options) {
     if (stdin.length) {

--- a/workspaces/varys/organizations.json.example
+++ b/workspaces/varys/organizations.json.example
@@ -5,7 +5,9 @@
     {
       "name": "philips-software"
     },
-    { "name": "philips-labs"
+    {
+      "name": "philips-labs",
+      "team": "innersource"
     }
   ],
   "slackToken": "<slackToken>",


### PR DESCRIPTION
This default team can be configured in organizations.json

Closes #5 

Example organizations part in json:
```
  "organizations": [
    { "name": "philips-labs"
    },
    {
      "name": "philips-software"
    },
    {
      "name": "philips-test-org",
      "team": "innersource"
    },
    {
      "name": "philips-forks"
    },
    {
      "name": "hsdp-customers"
    },
    {
      "name": "philips-internal",
      "team": "innersource"
    }
  ],```

New organizations.json can be found in keybase.