### PR TITLE
add option to add users by email

### DIFF
--- a/workspaces/varys/CHANGELOG.md
+++ b/workspaces/varys/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changes
 
+- #64 - Add option `-e` or `--email` to use email to invite people
 - #41 - Slack channel moved to configuration
 
 ## 0.0.1

--- a/workspaces/varys/bin/varys-users-add
+++ b/workspaces/varys/bin/varys-users-add
@@ -15,6 +15,7 @@ program
   .version(pkg.version)
   .description(pkg.description)
   .option('-o, --organization <organization-name>', 'To which organization')
+  .option('-e, --email', 'Use email address instead of username')
   .arguments('[users...]')
   .action(function(users, options) {
     if (stdin.length) {
@@ -25,6 +26,9 @@ program
       errorMessage('missing parameter')
       this.help()
       return 1
+    }
+    if (!options.email) {
+      options.email = false
     }
     infoMessage(`add following users: ${users.join(', ')}`)
     addUsers(defaultConfiguration, { users, ...options })

--- a/workspaces/varys/lib/commands/add-user-graphql.js
+++ b/workspaces/varys/lib/commands/add-user-graphql.js
@@ -186,15 +186,29 @@ const getTeamId = async (team, organization) => {
   }
 }
 
-const inviteUser = async (username, organization, team) => {
+const inviteUser = async (username, organization, team, email) => {
   infoMessage(
     chalk`Add ${chalk.yellow(username)} to ${chalk.green(organization)}`
   )
 
   let payload = {
     org: organization,
-    invitee_id: await getUserId(username),
     role: 'direct_member'
+  }
+
+  if (!email) {
+    payload = {
+      ...payload,
+      invitee_id: await getUserId(username)
+    }
+  } else {
+    infoMessage(
+      chalk`Add user with email: ${chalk.yellow(username)}`
+    )
+    payload = {
+      ...payload,
+      email: username
+    }
   }
 
   if (team != '') {
@@ -235,7 +249,7 @@ const inviteUser = async (username, organization, team) => {
   console.log(data)
 }
 
-const addUsers = async (config, { organization, users }) => {
+const addUsers = async (config, { organization, users, email }) => {
   token = config.githubToken
   slackToken = config.slackToken
   slackChannel = config.slackChannel
@@ -249,11 +263,15 @@ const addUsers = async (config, { organization, users }) => {
       )} / ${chalk.yellow(team)}`
     )
 
-    await checkUser(user, organization)
-    await checkAlreadyInvited(user, organization)
-    await checkBlocked(user, organization)
+    if (!email) {
+      await checkUser(user, organization)
+      await checkAlreadyInvited(user, organization)
+      await checkBlocked(user, organization)
+    } else {
+      infoMessage(chalk`You're using an email address, so no additional checks are performed`)
+    }
     await verify()
-    await inviteUser(user, organization, team)
+    await inviteUser(user, organization, team, email)
   })
 }
 


### PR DESCRIPTION
Now you can add `-e` or `--email` to use an email to invite people.

This is NOT the recommended way, because we cannot perform checks on users wih an email-address.

## Examples
```
./bin/varys users add -e -o philips-internal johndoo@example.com`
```
or
```
./bin/varys users add --email -o philips-internal johndoo@example.com`
```

closes #64


